### PR TITLE
Fallback to default port when $PORT var not passed

### DIFF
--- a/build.go
+++ b/build.go
@@ -10,8 +10,9 @@ func Build(logger scribe.Logger) packit.BuildFunc {
 		logger.Title("%s %s", context.BuildpackInfo.Name, context.BuildpackInfo.Version)
 
 		logger.Process("Writing start command")
-		command := "bundle exec rackup -p ${PORT}"
-		logger.Subprocess("`%s`", command)
+		// 9292 is the default rackup port
+		command := `bundle exec rackup -p "${PORT:-9292}"`
+		logger.Subprocess(command)
 
 		return packit.BuildResult{
 			Processes: []packit.Process{

--- a/build_test.go
+++ b/build_test.go
@@ -73,7 +73,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			Processes: []packit.Process{
 				{
 					Type:    "web",
-					Command: "bundle exec rackup -p ${PORT}",
+					Command: `bundle exec rackup -p "${PORT:-9292}"`,
 				},
 			},
 		}))

--- a/integration/sinatra_app_test.go
+++ b/integration/sinatra_app_test.go
@@ -81,7 +81,7 @@ func testSinatraApp(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				fmt.Sprintf("Rackup Buildpack %s", buildpackVersion),
 				"  Writing start command",
-				"    `bundle exec rackup -p ${PORT}`",
+				`    bundle exec rackup -p "${PORT:-9292}"`,
 			))
 		})
 	})


### PR DESCRIPTION
Previously, docker run <myrackapp> wouldn't have run
without a `-e PORT=<port>`

Signed-off-by: Arjun Sreedharan <asreedharan@vmware.com>