### PR TITLE
Move main.go into run sub-package

### DIFF
--- a/build.go
+++ b/build.go
@@ -1,4 +1,4 @@
-package main
+package rackup
 
 import (
 	"github.com/paketo-buildpacks/packit"

--- a/build_test.go
+++ b/build_test.go
@@ -1,4 +1,4 @@
-package main_test
+package rackup_test
 
 import (
 	"bytes"
@@ -8,7 +8,7 @@ import (
 
 	"github.com/paketo-buildpacks/packit"
 	"github.com/paketo-buildpacks/packit/scribe"
-	main "github.com/paketo-community/rackup"
+	"github.com/paketo-community/rackup"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
@@ -40,7 +40,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		buffer = bytes.NewBuffer(nil)
 		logger := scribe.NewLogger(buffer)
 
-		build = main.Build(logger)
+		build = rackup.Build(logger)
 	})
 
 	it.After(func() {

--- a/detect.go
+++ b/detect.go
@@ -1,4 +1,4 @@
-package main
+package rackup
 
 import (
 	"fmt"

--- a/detect_test.go
+++ b/detect_test.go
@@ -1,4 +1,4 @@
-package main_test
+package rackup_test
 
 import (
 	"errors"
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/paketo-buildpacks/packit"
-	main "github.com/paketo-community/rackup"
+	"github.com/paketo-community/rackup"
 	"github.com/paketo-community/rackup/fakes"
 	"github.com/sclevine/spec"
 
@@ -37,7 +37,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 		gemfileLockParser = &fakes.GemParser{}
 
-		detect = main.Detect(gemfileLockParser)
+		detect = rackup.Detect(gemfileLockParser)
 	})
 
 	it.After(func() {
@@ -56,19 +56,19 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				Requires: []packit.BuildPlanRequirement{
 					{
 						Name: "gems",
-						Metadata: main.BuildPlanMetadata{
+						Metadata: rackup.BuildPlanMetadata{
 							Launch: true,
 						},
 					},
 					{
 						Name: "bundler",
-						Metadata: main.BuildPlanMetadata{
+						Metadata: rackup.BuildPlanMetadata{
 							Launch: true,
 						},
 					},
 					{
 						Name: "mri",
-						Metadata: main.BuildPlanMetadata{
+						Metadata: rackup.BuildPlanMetadata{
 							Launch: true,
 						},
 					},
@@ -93,19 +93,19 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				Requires: []packit.BuildPlanRequirement{
 					{
 						Name: "gems",
-						Metadata: main.BuildPlanMetadata{
+						Metadata: rackup.BuildPlanMetadata{
 							Launch: true,
 						},
 					},
 					{
 						Name: "bundler",
-						Metadata: main.BuildPlanMetadata{
+						Metadata: rackup.BuildPlanMetadata{
 							Launch: true,
 						},
 					},
 					{
 						Name: "mri",
-						Metadata: main.BuildPlanMetadata{
+						Metadata: rackup.BuildPlanMetadata{
 							Launch: true,
 						},
 					},

--- a/gemfile_lock_parser.go
+++ b/gemfile_lock_parser.go
@@ -1,4 +1,4 @@
-package main
+package rackup
 
 import (
 	"bufio"

--- a/gemfile_lock_parser_test.go
+++ b/gemfile_lock_parser_test.go
@@ -1,11 +1,11 @@
-package main_test
+package rackup_test
 
 import (
 	"io/ioutil"
 	"os"
 	"testing"
 
-	main "github.com/paketo-community/rackup"
+	"github.com/paketo-community/rackup"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
@@ -16,7 +16,7 @@ func testGemfileLockParser(t *testing.T, context spec.G, it spec.S) {
 		Expect = NewWithT(t).Expect
 
 		path   string
-		parser main.GemfileLockParser
+		parser rackup.GemfileLockParser
 	)
 
 	it.Before(func() {
@@ -45,7 +45,7 @@ DEPENDENCIES
 
 		path = file.Name()
 
-		parser = main.NewGemfileLockParser()
+		parser = rackup.NewGemfileLockParser()
 	})
 
 	it.After(func() {

--- a/init_test.go
+++ b/init_test.go
@@ -1,4 +1,4 @@
-package main_test
+package rackup_test
 
 import (
 	"testing"

--- a/run/main.go
+++ b/run/main.go
@@ -5,14 +5,15 @@ import (
 
 	"github.com/paketo-buildpacks/packit"
 	"github.com/paketo-buildpacks/packit/scribe"
+	"github.com/paketo-community/rackup"
 )
 
 func main() {
 	logger := scribe.NewLogger(os.Stdout)
-	parser := NewGemfileLockParser()
+	parser := rackup.NewGemfileLockParser()
 
-	detect := Detect(parser)
-	build := Build(logger)
-
-	packit.Run(detect, build)
+	packit.Run(
+		rackup.Detect(parser),
+		rackup.Build(logger),
+	)
 }


### PR DESCRIPTION
This ensures that we don't have issues with importing `main` if that needs to happen.